### PR TITLE
Simplify dependencies and make code compile offline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -534,26 +534,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde"
-version = "1.0.219"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
-dependencies = [
- "serde_derive",
-]
-
-[[package]]
-name = "serde_derive"
-version = "1.0.219"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -706,9 +686,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "log",
  "rand",
  "rumqttc",
- "serde",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "white-noise-machine"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 
 [dependencies]
-anyhow = "1.0.98"
-clap = "4.5.43"
+anyhow = "1"
+clap = { version = "4" }
+log = "0.4"
 rand = "0.9.2"
-rumqttc = "0.24.0"
-serde = "1.0.219"
-tokio = "1.47.1"
+rumqttc = { version = "0.24", default-features = false, features = ["use-rustls"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
## Summary
- remove unused heavy crates and pin minimal dependencies
- replace macro-based CLI parsing with builder API
- implement manual MQTT discovery JSON and simplify player shutdown

## Testing
- `cargo test --offline`
- `cargo run --offline -- --help`


------
https://chatgpt.com/codex/tasks/task_e_68981876a0bc832cb546815a8ce82e6f